### PR TITLE
ページの変更を監視して処理を実行するように変更

### DIFF
--- a/src/content_scripts/events/event-emits.ts
+++ b/src/content_scripts/events/event-emits.ts
@@ -1,5 +1,5 @@
 import eventHandler, { EventType } from './event-handler';
 
-export default (event: EventType) => {
-  eventHandler(event);
+export default async (event: EventType) => {
+  await eventHandler(event);
 };

--- a/src/content_scripts/events/event-handler.ts
+++ b/src/content_scripts/events/event-handler.ts
@@ -10,24 +10,29 @@ export const events = [
 ] as const;
 
 export type EventType = typeof events[number];
-export default (event: EventType) => {
-  switch (event) {
-    case 'processing':
-      ActionsStatusDisplay.changeStatus(event);
-      ReviwersDisplay.disable();
-      break;
-    case 'passed':
-      ActionsStatusDisplay.changeStatus(event);
-      ReviwersDisplay.enable();
-      break;
-    case 'fail':
-      ActionsStatusDisplay.changeStatus(event);
-      ReviwersDisplay.disable();
-      break;
-    case 'init':
-      ReviwersDisplay.disable();
-      break;
-    default:
-      throw new Error('unknown event');
+export default async (event: EventType) => {
+  try {
+    switch (event) {
+      case 'processing':
+        ActionsStatusDisplay.changeStatus(event);
+        ReviwersDisplay.disable();
+        break;
+      case 'passed':
+        ActionsStatusDisplay.changeStatus(event);
+        ReviwersDisplay.enable();
+        break;
+      case 'fail':
+        ActionsStatusDisplay.changeStatus(event);
+        ReviwersDisplay.disable();
+        break;
+      case 'init':
+        await ActionsStatusDisplay.initialize();
+        await ReviwersDisplay.initialize();
+        break;
+      default:
+        throw new Error('unknown event');
+    }
+  } catch (e) {
+    console.error(e);
   }
 };

--- a/src/content_scripts/presenters/actions-status-display.ts
+++ b/src/content_scripts/presenters/actions-status-display.ts
@@ -7,7 +7,7 @@ export default class ActionsStatusDisplay {
 
   static actionStatusSrcDom: HTMLDivElement | null = null;
 
-  static initialize() {
+  static async initialize() {
     this.actionStatusDom.classList.add(
       'discussion-sidebar-item',
       'sidebar-actions-status',
@@ -19,8 +19,18 @@ export default class ActionsStatusDisplay {
     this.labelDom.innerHTML = 'Actions status';
     this.statusDom.innerHTML = '';
 
-    const reviewersDom = document.querySelector('.sidebar-assignee');
-    if (!reviewersDom || !reviewersDom.parentElement) {
+    const reviewersDom = await new Promise<HTMLDivElement>((r) => {
+      const intervalId = setInterval(() => {
+        const dom = document.querySelector<HTMLDivElement>('.sidebar-assignee');
+        if (!dom) {
+          return;
+        }
+        r(dom);
+        clearInterval(intervalId);
+      }, 200);
+    });
+
+    if (!reviewersDom.parentElement) {
       throw new Error('not found reviewers dom');
     }
 
@@ -38,5 +48,3 @@ export default class ActionsStatusDisplay {
     this.statusDom.innerHTML = `<span style="color:${color}">${status}</span>`;
   }
 }
-
-ActionsStatusDisplay.initialize();

--- a/src/content_scripts/presenters/reviewers-display.ts
+++ b/src/content_scripts/presenters/reviewers-display.ts
@@ -1,20 +1,36 @@
 export default class ReviwersDisplay {
-  static reviewersDom = (() => {
-    const reviewersDom =
-      document.querySelector<HTMLDivElement>('.sidebar-assignee');
-    if (!reviewersDom) {
-      throw new Error('not found reviewer dom');
-    }
-    return reviewersDom;
-  })();
+  static reviewersDom: HTMLDivElement | null;
+
+  static async initialize() {
+    this.reviewersDom = await new Promise<HTMLDivElement>((r) => {
+      const intervalId = setInterval(() => {
+        const dom = document.querySelector<HTMLDivElement>('.sidebar-assignee');
+        if (!dom) {
+          return;
+        }
+        r(dom);
+        clearInterval(intervalId);
+      }, 200);
+    });
+
+    this.disable();
+  }
 
   static disable(): void {
+    if (!this.reviewersDom) {
+      throw new Error('DOM is not found');
+    }
+
     this.reviewersDom.style.cursor = 'not-allowed';
     (this.reviewersDom.children[0] as HTMLFormElement).style.pointerEvents =
       'none';
   }
 
   static enable(): void {
+    if (!this.reviewersDom) {
+      throw new Error('DOM is not found');
+    }
+
     this.reviewersDom.style.cursor = 'auto';
     (this.reviewersDom.children[0] as HTMLFormElement).style.pointerEvents =
       'auto';


### PR DESCRIPTION
SPAでURL変更時にスクリプトが実行されないため、
DOMの変更を監視して実行するようにした